### PR TITLE
Fix CAT for radio, add mode get/set

### DIFF
--- a/src/radio.c
+++ b/src/radio.c
@@ -528,7 +528,6 @@ void radio_restore_mode(x6100_mode_t mode) {
 }
 
 void radio_change_mode(radio_mode_t select) {
-    params_lock();
 
     x6100_mode_t    mode = radio_current_mode();
 

--- a/src/radio.c
+++ b/src/radio.c
@@ -506,6 +506,7 @@ void radio_filter_get(int32_t *from_freq, int32_t *to_freq) {
 }
 
 void radio_set_mode(x6100_vfo_t vfo,  x6100_mode_t mode) {
+    params_lock();
     params_band.vfo_x[vfo].mode = mode;
     params_unlock(&params_band.vfo_x[vfo].durty.mode);
 


### PR DESCRIPTION
Original FW sends echo for input command.
Also, is uses sender address as destination in reply and A4 as radio
address.
```
-> FE FE 00 E0 04 FD
<- FE FE 00 E0 04 FD
<- FE FE E0 A4 04 01 01 FD
```

Tested on hamlog agent - working in both directions for mode and freq.